### PR TITLE
Change lua-resty-http requirement namespace

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -7,5 +7,5 @@ lib_dir = lib
 doc_dir = lib
 repo_link = https://github.com/fffonion/lua-resty-acme
 main_module = lib/resty/acme/client.lua
-requires = luajit, openresty/lua-resty-lrucache >= 0.08, pintsized/lua-resty-http >= 0.12, fffonion/lua-resty-openssl >= 0.5.2, spacewander/luafilesystem >= 0.1
+requires = luajit, openresty/lua-resty-lrucache >= 0.08, ledgetech/lua-resty-http >= 0.12, fffonion/lua-resty-openssl >= 0.5.2, spacewander/luafilesystem >= 0.1
 exclude_files=*.rock, *.rockspec


### PR DESCRIPTION
Looks like `lua-resty-http` some time ago moved from `pintsized` to `ledgetech` namespace (and consequently released 0.13 and 0.14 under new namespace). `lua-resty-s3` depends on newest version from `ledgetech`: https://github.com/jie123108/lua-resty-s3/blob/master/dist.ini#L11, while `lua-resty-acme` depends on `pintsized/lua-resty-http`, which leads to a error:
```
ERROR: failed to install pintsized/lua-resty-http: ledgetech/lua-resty-http 0.14 already installed.
```
when I try to install `lua-resty-acme` and `lua-resty-s3` at the same time.