### PR TITLE
Store account key in storage

### DIFF
--- a/lib/resty/acme/autossl.lua
+++ b/lib/resty/acme/autossl.lua
@@ -465,19 +465,16 @@ function AUTOSSL.load_account_key_storage()
 end
 
 function AUTOSSL.load_account_key(filepath)
-  if filepath then
-    local account_key_f, err = io.open(filepath)
-    if err then
-      error("can't open account_key file " .. filepath .. ": " .. err)
-    end
-    local account_key_pem, err = account_key_f:read("*a")
-    if err then
-      error("can't read account_key file " .. filepath .. ": " .. err)
-    end
-    account_key_f:close()
-    return account_key_pem
+  local account_key_f, err = io.open(filepath)
+  if err then
+    error("can't open account_key file " .. filepath .. ": " .. err)
   end
-  return nil
+  local account_key_pem, err = account_key_f:read("*a")
+  if err then
+    error("can't read account_key file " .. filepath .. ": " .. err)
+  end
+  account_key_f:close()
+  return account_key_pem
 end
 
 function AUTOSSL.get_certkey(domain, typ)

--- a/lib/resty/acme/autossl.lua
+++ b/lib/resty/acme/autossl.lua
@@ -70,7 +70,7 @@ local CERTS_CACHE_NEG_TTL = 5
 
 local update_cert_lock_key_prefix = "update_lock:"
 local domain_cache_key_prefix = "domain:"
-local account_private_key_prefix = "account_key"
+local account_private_key_prefix = "account_key:"
 
 -- get cert and key cdata with caching
 -- domain, typ, raw

--- a/lib/resty/acme/autossl.lua
+++ b/lib/resty/acme/autossl.lua
@@ -445,7 +445,7 @@ function AUTOSSL.load_account_key(config)
 
     local pkey, err = storage:get(account_private_key_prefix)
     if err then
-      error("Failed to read account key from stoage storage: " .. err)
+      error("Failed to read account key from storage: " .. err)
     end
 
     if not pkey then

--- a/lib/resty/acme/autossl.lua
+++ b/lib/resty/acme/autossl.lua
@@ -459,7 +459,7 @@ function AUTOSSL.load_account_key_storage()
       error("failed to save account_key: " .. err)
       return nil
     end
-    return generated_key
+    return AUTOSSL.generated_account_key
   end
   return pkey
 end

--- a/lib/resty/acme/autossl.lua
+++ b/lib/resty/acme/autossl.lua
@@ -441,6 +441,7 @@ function AUTOSSL.create_account_key()
   local t = ngx.now()
   local pkey = util.create_pkey(4096, 'RSA')
   ngx.update_time()
+  log(ngx_INFO, ngx.now() - t,  "s spent in creating new account key")
   return pkey
 end
 

--- a/lib/resty/acme/autossl.lua
+++ b/lib/resty/acme/autossl.lua
@@ -285,9 +285,9 @@ function AUTOSSL.init(autossl_config, acme_config)
     autossl_config.storage_adapter = "resty.acme.storage." .. autossl_config.storage_adapter
   end
 
-  local account_key = AUTOSSL.load_account_key(autossl_config.account_key_path)
-  acme_config.account_key = account_key
-  if not account_key then
+  if autossl_config.account_key_path then
+    acme_config.account_key = AUTOSSL.load_account_key(autossl_config.account_key_path)
+  else
     AUTOSSL.generated_account_key = AUTOSSL.create_account_key()
   end
 

--- a/lib/resty/acme/autossl.lua
+++ b/lib/resty/acme/autossl.lua
@@ -358,7 +358,7 @@ function AUTOSSL.init_worker()
 
   if not AUTOSSL.config.account_key_path then
     local account_key = AUTOSSL.load_account_key_storage()
-    local err = AUTOSSL.client:load_account_key(account_key)
+    local err = AUTOSSL.client:set_account_key(AUTOSSL.client, account_key)
     if err then
       error("failed to set account key: " .. err)
     end

--- a/lib/resty/acme/autossl.lua
+++ b/lib/resty/acme/autossl.lua
@@ -456,6 +456,7 @@ function AUTOSSL.load_account_key_storage()
     local err = storage:set(account_private_key_prefix, AUTOSSL.generated_account_key)
     if err then
       error("failed to save account_key: " .. err)
+      return nil
     end
     return generated_key
   end

--- a/lib/resty/acme/client.lua
+++ b/lib/resty/acme/client.lua
@@ -49,9 +49,10 @@ local function set_account_key(self, account_key)
   self.account_pkey = account_pkey
   local account_thumbprint, err = util.thumbprint(account_pkey)
   if err then
-    return "failed to calculate thumbprint: " .. err
+    return false, "failed to calculate thumbprint: " .. err
   end
   self.account_thumbprint = account_thumbprint
+  return true, nil
 end
 
 function _M.new(conf)
@@ -91,7 +92,7 @@ function _M.new(conf)
   end
 
   if conf.account_key then
-    local err = set_account_key(self, conf.account_key)
+    local ok, err = set_account_key(self, conf.account_key)
     if err then
       return nil, err
     end


### PR DESCRIPTION
No unit tests yet. But thoughts?

I've left it so that if no filepath is supplied it defaults to storage but if one is supplied it'll try to load it off the FS. Means that present configs wont break.