### PR TITLE
Draft: Add certificate renewal cooloff period

### DIFF
--- a/lib/resty/acme/autossl.lua
+++ b/lib/resty/acme/autossl.lua
@@ -38,6 +38,10 @@ local default_config = {
   domain_whitelist = nil,
   -- restrict registering new cert only with domain checked by this function
   domain_whitelist_callback = nil,
+  -- certificate failure cooloff period, in seconds
+  failure_cooloff = 300,
+  -- certificate failure cooloff optional function
+  failure_cooloff_callback = nil,
   -- the threshold to renew a cert before it expires, in seconds
   renew_threshold = 7 * 86400,
   -- interval to check cert renewal, in seconds
@@ -55,6 +59,7 @@ local domain_pkeys = {}
 
 local domain_key_types, domain_key_types_count
 local domain_whitelist, domain_whitelist_callback
+local failure_cooloff_callback
 
 --[[
   certs_cache = {
@@ -71,6 +76,7 @@ local CERTS_CACHE_NEG_TTL = 5
 local update_cert_lock_key_prefix = "update_lock:"
 local domain_cache_key_prefix = "domain:"
 local account_private_key_prefix = "account_key:"
+local certificate_failure_lock_key_prefix = "failure_lock:"
 
 -- get cert and key cdata with caching
 -- domain, typ, raw
@@ -209,6 +215,16 @@ function AUTOSSL.update_cert(data)
     AUTOSSL.client_initialized = true
   end
 
+
+  -- If its failed in the past and its still cooling down
+  -- we dont do anything right now
+  local failure_lock_key = certificate_failure_lock_key_prefix .. ":" .. data.domain
+  local failure_lock, _ = AUTOSSL.storage:get(failure_lock_key)
+  if failure_lock then
+    ngx.log(ngx.INFO, "failure lock key exists. Not updating ", data.domain, " right now")
+    return nil
+  end
+
   -- Note that we lock regardless of key types
   -- Let's encrypt tends to have a (undocumented?) behaviour that if
   -- you submit an order with different CSR while the previous order is still pending
@@ -222,6 +238,14 @@ function AUTOSSL.update_cert(data)
   end
 
   err = update_cert_handler(data)
+
+  if err then
+    if failure_cooloff_callback then
+      failure_cooloff_callback(domain, failure_lock_key, AUTOSSL.storage)
+    else
+      AUTOSSL.storage:add(failure_lock_key, "1", AUTOSSL.config.failure_cooloff)
+    end
+  end
 
   -- yes we don't release lock, but wait it to expire after negative cache is cleared
   return err
@@ -317,6 +341,16 @@ function AUTOSSL.init(autossl_config, acme_config)
   if not domain_whitelist and not domain_whitelist_callback then
     ngx.log(ngx.WARN, "neither domain_whitelist or domain_whitelist_callback is defined, this may cause",
                       "security issues as all SNI will trigger a creation of certificate")
+  end
+
+  failure_cooloff_callback = autossl_config.failure_cooloff_callback
+  if failure_cooloff_callback and type(failure_cooloff_callback) ~= "function" then
+    error("failure_cooloff_callback must be a function, got " .. type(failure_cooloff_callback))
+  end
+
+  if not failure_cooloff and not failure_cooloff_callback then
+    ngx.log(ngx.WARN, "neither failure_cooloff or failure_cooloff_callback is defined",
+                      "any certificate failure will not cooloff which may trigger LE API limits")
   end
 
   for _, typ in ipairs(domain_key_types) do


### PR DESCRIPTION
Initial work at failure backoff for #20 

### What does this do?

Enables a configurable option that locks autossl from attempting to renew or generate a certificate for a domain after it has failed for a configurable cooloff period. Optionally a user can supply a function that they wish to use to control this behavior. If the user supplies a function they must take care of inserting the lock into the AUTOSSL Storage. 

Presently the lock time defaults to 5 minutes


#### Why allow a function as well?

I figured some people would want to be able to make this lock out time dynamic as well. Example.

1. First failure is only 5 minute lock time (could be DNS propagating etc). 
2. Second failure might be slightly longer at 15 minutes
3. Third and beyond is a 20 minute cooldown

### What else is left

- [ ] Update docs
- [ ] Write tests

### Further notes

Haven't tested it fully but thought I'd add a PR as I work on it.

This requires #24 to be fixed before it'll work
