### PR TITLE
Check if domain is set before trying to alter it

### DIFF
--- a/lib/resty/acme/autossl.lua
+++ b/lib/resty/acme/autossl.lua
@@ -384,12 +384,13 @@ end
 function AUTOSSL.ssl_certificate()
   local domain, err = ssl.server_name()
 
-  domain = string.lower(domain)
-
   if err or not domain then
     log(ngx_INFO, "ignore domain ", domain, ", err: ", err)
     return
   end
+
+  domain = string.lower(domain)
+
   if domain_whitelist_callback and not domain_whitelist_callback(domain) then
     log(ngx_INFO, "domain ", domain, " does not pass whitelist_callback, skipping")
     return


### PR DESCRIPTION
If a request comes in over HTTPS but with no SNI headers `ssl.server_name()` returns nil, trying to do string operations on that causes errors. The code bails out below anyway but this stops bogus errors from appearing in the logs.

I don't believe string.lower can ever return `nil` or anything that isn't a string (as long as it gets a string) so this should be safe.

error that happens below

```
2021/01/13 20:10:33 [error] 4631#0: *16809 lua entry thread aborted: runtime error: autossl.lua:387: bad argument #1 to 'lower' (string expected, got nil)
stack traceback:
coroutine 0:
	[C]: in function 'lower'
	autossl.lua:387: in function 'ssl_certificate'
	ssl_certificate_by_lua:2: in main chunk, context: ssl_certificate_by_lua*, client: SNIP, server: 0.0.0.0:443
2021/01/13 20:10:33 [crit] 4631#0: *16808 SSL_do_handshake() failed (SSL: error:1417A179:SSL routines:tls_post_process_client_hello:cert cb error) while SSL handshaking, client: SNIP, server: 0.0.0.0:443
```