### PR TITLE
Do not force /directory at the end of api_url

### DIFF
--- a/lib/resty/acme/client.lua
+++ b/lib/resty/acme/client.lua
@@ -126,14 +126,6 @@ function _M:init()
   local httpc = new_httpc()
 
   local url = self.conf.api_uri
-  -- we accept both API endpoint with or without /directory
-  -- to avoid confusion
-  if not ngx.re.match(url, "/directory$") then
-    if not ngx.re.match(url, "/$") then
-      url = url .. "/"
-    end
-    url = url .. "directory"
-  end
 
   local resp, err = httpc:request_uri(url)
   if err then

--- a/lib/resty/acme/client.lua
+++ b/lib/resty/acme/client.lua
@@ -125,9 +125,7 @@ _M.set_account_key = set_account_key
 function _M:init()
   local httpc = new_httpc()
 
-  local url = self.conf.api_uri
-
-  local resp, err = httpc:request_uri(url)
+  local resp, err = httpc:request_uri(self.conf.api_uri)
   if err then
     return "acme directory request failed: " .. err
   end


### PR DESCRIPTION
**This is a breaking change!**

ACME appends `/directory` to the api_url if it does not have this suffix. This breaks compatibility with ACME servers that do not expose directory at `/directory` path. A good example is [Pebble](https://github.com/letsencrypt/pebble) – official Let'sEncrypt RFC 8555 ACME test server, which intentionally runs directory at `/dir` path: 

> Where possible Pebble will make decisions that force clients to implement ACME correctly (e.g. randomizing /directory endpoint URLs to ensure clients are not hardcoding URLs.)

Right now, I'm unable to connect to Pebble without this patch to do some extra testing (we're planning to migrate pretty large installation).

@fffonion, any opinions how to fix this without (possibly) breaking existing setups? 