### PR TITLE
Trigger only pending challenges

### DIFF
--- a/lib/resty/acme/client.lua
+++ b/lib/resty/acme/client.lua
@@ -483,6 +483,7 @@ function _M:order_certificate(domain_key, ...)
   local authzs = order_body.authorizations
   local registered_challenges = {}
   local registered_challenge_count = 0
+  local has_valid_challenge = false
 
   for _, authz in ipairs(authzs) do
     -- POST-as-GET request with empty payload
@@ -498,31 +499,38 @@ function _M:order_certificate(domain_key, ...)
     for _, challenge in ipairs(challenges.challenges) do
       local typ = challenge.type
       if self.challenge_handlers[typ] then
-        local err = self.challenge_handlers[typ]:register_challenge(
-          challenge.token,
-          challenge.token .. "." .. self.account_thumbprint,
-          {...}
-        )
-        if err then
-          return nil, "error registering challenge: " .. err
-        end
-        registered_challenges[registered_challenge_count + 1] = challenge.token
-        registered_challenge_count = registered_challenge_count + 1
-        log(ngx_DEBUG, "register challenge ", typ, ": ", challenge.token)
-        -- signal server to start challenge check
-        -- needs to be empty json body rather than empty string
-        -- https://tools.ietf.org/html/rfc8555#section-7.5.1
-        local _, _, err = self:post(challenge.url, {})
-        if err then
-          return nil, "error start challenge check: " .. err
+        if challenge.status == 'pending' then
+          local err = self.challenge_handlers[typ]:register_challenge(
+            challenge.token,
+            challenge.token .. "." .. self.account_thumbprint,
+            {...}
+          )
+          if err then
+            return nil, "error registering challenge: " .. err
+          end
+          registered_challenges[registered_challenge_count + 1] = challenge.token
+          registered_challenge_count = registered_challenge_count + 1
+          log(ngx_DEBUG, "register challenge ", typ, ": ", challenge.token)
+          -- signal server to start challenge check
+          -- needs to be empty json body rather than empty string
+          -- https://tools.ietf.org/html/rfc8555#section-7.5.1
+          local _, _, err = self:post(challenge.url, {})
+          if err then
+            return nil, "error start challenge check: " .. err
+          end
+        else
+          if challenge.status == 'valid' then
+            has_valid_challenge = true
+          end
+          log(ngx_DEBUG, "challenge ", typ, ": ", challenge.token, " is ", challenge.status, ", skipping")
         end
       end
     end
 ::nextchallenge::
   end
 
-  if registered_challenge_count == 0 then
-    return nil, "no challenge is registered"
+  if registered_challenge_count == 0 and has_valid_challenge == false then
+    return nil, "no challenge is registered and no challenge is valid"
   end
 
   -- Wait until the order is ready


### PR DESCRIPTION
Another small glitch with certificate renewal found while testing with Pebble as I mentioned previously in PR #31 and #30. 

In some cases, a challenge may be already validated by ACME (possibly due to another bug or Pebble checking our implementation against RFC). That would fail with the message `Cannot update challenge with status valid, only status pending`.

This PR fixes that. We should only process challenge (register, then signal) when its state is `pending`. Also, we should continue certificate order process there is a valid challenge already while no other challenges were registered.