### PR TITLE
Fix: get_certkey returning cdata instead of string for raw requests

### DIFF
--- a/lib/resty/acme/autossl.lua
+++ b/lib/resty/acme/autossl.lua
@@ -78,7 +78,7 @@ local function get_certkey(opts)
   local typ = opts.type
   local domain = opts.domain
   local data, _ --[[stale]], _ --[[flags]] = certs_cache[typ]:get(domain)
-  if data then
+  if data and not opts.raw then
     return data, nil
   end
 


### PR DESCRIPTION
Certificate renew attempt would fail sometimes with the following message:
```
2031/01/18 12:51:31 [debug] 10#10: *51 [lua] client.lua:398: watch_order_status(): check order: {"expires":"2031-01-19T12:51:28Z","finalize":"https://pebble:14000/finalize-order/Drq6dFCzO-ofmWQhXvaBHu2OxhNItQdSJjuV6mlPzn0","status":"ready","authorizations":["https://pebble:14000/authZ/0HlgB1IntdqFlWHFx19wZu3gPq8isjAaDX34mApbN-A"],"identifiers":[{"value":"somedomain.local","type":"dns"}]}
2031/01/18 12:51:31 [error] 10#10: *51 [lua] autossl.lua:174: update_cert_handler(): error updating cert for somedomain.local err: failed to load domain pkey: pkey.new: expect a EVP_PKEY* cdata at #1, context: ngx.timer
2031/01/18 12:51:31 [error] 10#10: *51 [lua] autossl.lua:263: failed to renew certificate for domain somedomain.local, context: ngx.timer
```

Private key is loaded in https://github.com/kfigiela/lua-resty-acme/blob/5635efa4b190d2814e9a9f3d4f30d06072e597ea/lib/resty/acme/autossl.lua#L145 
then parsed by openssl library in https://github.com/kfigiela/lua-resty-acme/blob/eb56f0502900e971afb527de55ee1faca2f1fc50/lib/resty/acme/client.lua#L534

Caching feature of `get_certkey` would cause cdata to be returned for raw queries in some cases.
