### PR TITLE
Retry on bad nonce

### DIFF
--- a/lib/resty/acme/client.lua
+++ b/lib/resty/acme/client.lua
@@ -184,9 +184,10 @@ end
 
 --- Enclose the provided payload in JWS
 --
--- @param url        ACME service URL
+-- @param url       ACME service URL
 -- @param payload   (json) data which will be wrapped in JWS
-function _M:jws(url, payload)
+-- @param nonce     nonce to be used in JWS, if not provided new nonce will be requested
+function _M:jws(url, payload, nonce)
   if not self.account_pkey then
     return nil, "account key does not specified"
   end
@@ -195,9 +196,12 @@ function _M:jws(url, payload)
     return nil, "url is not defined"
   end
 
-  local nonce, err = self:new_nonce()
-  if err then
-    return nil, "can't get new nonce from acme server"
+  if nonce == nil then
+    local err
+    nonce, err = self:new_nonce()
+    if err then
+      return nil, "can't get new nonce from acme server"
+    end
   end
 
   local jws = {
@@ -268,7 +272,7 @@ end
 -- @param headers   Lua table with request headers
 --
 -- @return Response object or tuple (nil, msg) on errors
-function _M:post(url, payload, headers)
+function _M:post(url, payload, headers, nonce)
   local httpc = new_httpc()
   if not headers then
     headers = {
@@ -278,7 +282,7 @@ function _M:post(url, payload, headers)
     headers["content-type"] = "application/jose+json"
   end
 
-  local jws, err = self:jws(url, payload)
+  local jws, err = self:jws(url, payload, nonce)
   if not jws then
     return nil, nil, err
   end
@@ -301,7 +305,12 @@ function _M:post(url, payload, headers)
     body = json.decode(resp.body)
   elseif resp.headers['Content-Type']:sub(1, 24) == "application/problem+json" then
     body = json.decode(resp.body)
-    return nil, nil, body.detail or body.type
+    if body.type == 'urn:ietf:params:acme:error:badNonce' then
+      log(ngx_DEBUG, "bad nonce: recoverable error, retrying")
+      return self:post(url, payload, headers, resp.headers["Replay-Nonce"])
+    else
+      return nil, nil, body.detail or body.type
+    end
   else
     body = resp.body
   end


### PR DESCRIPTION
While it's not a requirement, we may want to handle `badNonce` error gracefully and retry request. 

See: https://github.com/letsencrypt/pebble#invalid-anti-replay-nonce-errors

https://tools.ietf.org/html/rfc8555#section-6.5
> When a server rejects a request because its nonce value was unacceptable (or not present), it MUST provide HTTP status code 400 (Bad Request), and indicate the ACME error type "urn:ietf:params:acme:error:badNonce".  An error response with the "badNonce" error type MUST include a Replay-Nonce header field with a fresh nonce that the server will accept in a retry of the original query (and possibly in other requests, according to the server's nonce scoping policy).  On receiving such a response, a client SHOULD retry the request using the new nonce.
> [...]
>  However, when retrying in response to a "badNonce" error, the client MUST use the nonce provided in the error response.