### PR TITLE
Check if domain is whitelisted before cert renewal

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ domain_whitelist = { "domain1.com", "domain2.com", "domain3.com" },
 To match a pattern in your domain name, for example all subdomains under `example.com`, use:
 
 ```lua
-domain_whitelist_callback = function(domain, source)
+domain_whitelist_callback = function(domain, is_new_cert_needed)
     return ngx.re.match(domain, [[\.example\.com$]], "jo")
 end
 ```
@@ -158,7 +158,7 @@ It's possible to use cosocket API here. Do note that this will increase the SSL 
 latency.
 
 ```lua
-domain_whitelist_callback = function(domain, source)
+domain_whitelist_callback = function(domain, is_new_cert_needed)
     -- send HTTP request
     local http = require("resty.http")
     local res, err = httpc:request_uri("http://example.com")
@@ -169,10 +169,8 @@ domain_whitelist_callback = function(domain, source)
 end}),
 ```
 
-`domain_whitelist_callback` function is provided request source as a second argument,
-which can be either `server` (on incoming HTTP request) or `update_cert`
-(when certificate is generated or renewed). This allows to use cached
-values on hot path (`server`) while fetching fresh data on `update_cert`.
+`domain_whitelist_callback` function is provided with a second argument,
+which indicates whether the certificate is about to be served on incoming HTTP request (false) or new certificate is about to be requested (true). This allows to use cached values on hot path (serving requests) while fetching fresh data from storage for new certificates. One may also implement different logic, e.g. do extra checks before requesting new cert.
 
 ## tls-alpn-01 challenge
 

--- a/lib/resty/acme/autossl.lua
+++ b/lib/resty/acme/autossl.lua
@@ -209,7 +209,7 @@ function AUTOSSL.update_cert(data)
     AUTOSSL.client_initialized = true
   end
 
-  if not AUTOSSL.is_domain_whitelisted(data.domain, 'update_cert') then
+  if not AUTOSSL.is_domain_whitelisted(data.domain, true) then
     return "cert update is not allowed for domain " .. data.domain
   end
 
@@ -384,10 +384,9 @@ function AUTOSSL.serve_tls_alpn_challenge()
   AUTOSSL.client:serve_tls_alpn_challenge()
 end
 
--- source = server | update_cert
-function AUTOSSL.is_domain_whitelisted(domain, source)
+function AUTOSSL.is_domain_whitelisted(domain, is_new_cert_needed)
   if domain_whitelist_callback then
-    return domain_whitelist_callback(domain, source)
+    return domain_whitelist_callback(domain, is_new_cert_needed)
   elseif domain_whitelist then
     return domain_whitelist[domain]
   else
@@ -405,7 +404,7 @@ function AUTOSSL.ssl_certificate()
 
   domain = string.lower(domain)
 
-  if not AUTOSSL.is_domain_whitelisted(domain, 'server') then
+  if not AUTOSSL.is_domain_whitelisted(domain, false) then
     log(ngx_INFO, "domain ", domain, " not in whitelist, skipping")
     return
   end


### PR DESCRIPTION
I'd like to prevent renewals on domains that are no longer whitelisted. To implement this I've extracted whitelist check to the separate function and use this in `update_cert`. 

Also, since I'm gonna use dynamic whitelist with some caching in the worker process, I'd like to bypass cache for lookups during renewal. I've added `source` argument to `domain_whitelist_callback` function. 

@fffonion, do you have any thoughts on this?  

This is somehow related to #15. 