### PR TITLE
Increase cert lock time

### DIFF
--- a/lib/resty/acme/autossl.lua
+++ b/lib/resty/acme/autossl.lua
@@ -69,6 +69,7 @@ local domain_whitelist, domain_whitelist_callback
 local certs_cache = {}
 local CERTS_CACHE_TTL = 3600
 local CERTS_CACHE_NEG_TTL = 5
+local CERTS_LOCK_TTL = 300
 
 
 local update_cert_lock_key_prefix = "update_lock:"
@@ -225,7 +226,7 @@ function AUTOSSL.update_cert(data)
   -- you submit an order with different CSR while the previous order is still pending
   -- you will get the previous order (with `expires` capped to an integer second).
   local lock_key = update_cert_lock_key_prefix .. ":" .. data.domain
-  local err = AUTOSSL.storage:add(lock_key, "1", CERTS_CACHE_NEG_TTL)
+  local err = AUTOSSL.storage:add(lock_key, "1", CERTS_LOCK_TTL)
   if err then
     ngx.log(ngx.INFO,
       "update is already running (lock key ", lock_key, " exists), current type ", data.type)


### PR DESCRIPTION
There is a bug related when multiple instances of openresty are running (e.g. behind network load balancer). In such case, two instances may start certificate renewal at the same time (close enough). As indicated in https://github.com/fffonion/lua-resty-acme/issues/40#issuecomment-867602156

> Note, there is race condition between server instances as they all attempt renewals simultaneously. It causes some warning messages (and let's encrypt complaining about buggy client). You should increase lock expiration time as in this commit kfigiela@65b3451

This PR workarounds the issue by increasing lock TTL.