### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ http {
             require("resty.acme.autossl").ssl_certificate()
         }
 
-        location /.well-known {
+        location = /.well-known {
             content_by_lua_block {
                 require("resty.acme.autossl").serve_http_challenge()
             }


### PR DESCRIPTION
When using regular expressions to match non existing locations /.well-known could not get matched, adding '=' for prefix to location provides exact match.