### PR TITLE
Skip the execution of check_renew function on Nginx worker shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,8 @@ default_config = {
   enabled_challenge_handlers = { 'http-01' },
   -- time to wait before signaling ACME server to validate in seconds
   challenge_start_delay = 0,
+  -- whether renewal of certificates should happen before the nginx worker is shut down
+  renew_certs_on_shutdown = true,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -384,8 +384,6 @@ default_config = {
   enabled_challenge_handlers = { 'http-01' },
   -- time to wait before signaling ACME server to validate in seconds
   challenge_start_delay = 0,
-  -- whether renewal of certificates should happen before the nginx worker is shut down
-  renew_certs_on_shutdown = true,
 }
 ```
 

--- a/lib/resty/acme/autossl.lua
+++ b/lib/resty/acme/autossl.lua
@@ -56,8 +56,6 @@ local default_config = {
   enabled_challenge_handlers = { 'http-01' },
   -- time to wait before signaling ACME server to validate in seconds
   challenge_start_delay = 0,
-  -- whether renewal of certificates should happen before the nginx worker is shut down
-  renew_certs_on_shutdown = true,
 }
 
 local domain_pkeys = {}
@@ -286,11 +284,9 @@ end
 function AUTOSSL.check_renew(premature)
 
   -- According to docs in https://github.com/openresty/lua-nginx-module#ngxtimerat, a premature
-  -- timer expiration occurs when the nginx worker is trying to shut  down.  With  the  default
-  -- configuration, the renew  certificates  will  happen  just  before  shutdown.  However, if
-  -- renew_certs_on_shutdown is set to false, renewal of certificates on shutdown will  not  be
-  -- run  when nginx worker is shutting down.
-  if premature and not AUTOSSL.config.renew_certs_on_shutdown then
+  -- timer expiration occurs when the nginx worker is trying to shut down. Here we are skipping
+  -- running this on shutdown, as it can be problematic
+  if premature then
     return
   end
 

--- a/lib/resty/acme/autossl.lua
+++ b/lib/resty/acme/autossl.lua
@@ -285,7 +285,7 @@ function AUTOSSL.check_renew(premature)
 
   -- According to docs in https://github.com/openresty/lua-nginx-module#ngxtimerat, a premature
   -- timer expiration occurs when the nginx worker is trying to shut down. Here we are skipping
-  -- running this on shutdown, as it can be problematic
+  -- running this on Nginx worker shutdown, as it can be problematic
   if premature then
     return
   end

--- a/lib/resty/acme/autossl.lua
+++ b/lib/resty/acme/autossl.lua
@@ -56,6 +56,7 @@ local default_config = {
   enabled_challenge_handlers = { 'http-01' },
   -- time to wait before signaling ACME server to validate in seconds
   challenge_start_delay = 0,
+  -- whether renewal of certificates should happen before the nginx worker is shut down
   renew_certs_on_shutdown = true,
 }
 


### PR DESCRIPTION
When an Nginx worker is shut down, all the timers defined are [expired prematurely](https://github.com/openresty/lua-nginx-module#ngxtimerat). This results in [check_renew](https://github.com/fffonion/lua-resty-acme/blob/master/lib/resty/acme/autossl.lua#L284) function being called just before shutdown.  

With the changes in this PR, the renew_certs function will not be run on Nginx worker shutdowns

closes #57 