### PR TITLE
feat(autossl): add blocking mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,8 @@ default_config = {
   enabled_challenge_handlers = { 'http-01' },
   -- time to wait before signaling ACME server to validate in seconds
   challenge_start_delay = 0,
+  -- if true, the request to nginx waits until the cert has been generated and it is used right away
+  blocking = false,
 }
 ```
 


### PR DESCRIPTION
Add a `blocking` option, when `true` the master request to nginx waits for the cert to have been generated and we try to use it right away (similar to what https://github.com/auto-ssl/lua-resty-auto-ssl does).

Please note that I'm not familiar with the project or with LUA. I'm not sure this doesn't break anything or works for all use cases. It works fine in my tests so far.