### PR TITLE
Expose a function to get cert from the LRU cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,8 @@ default_config = {
   enabled_challenge_handlers = { 'http-01' },
   -- time to wait before signaling ACME server to validate in seconds
   challenge_start_delay = 0,
+  -- if true, the request to nginx waits until the cert has been generated and it is used right away
+  blocking = false,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ domain_whitelist_callback = function(domain, is_new_cert_needed)
     local res, err = httpc:request_uri("http://example.com")
     -- access the storage
     local value, err = require("resty.acme.autossl").storage:get("key")
+    -- get cert from resty LRU cache
+    -- cached = { pkey, cert } or nil if cert is not in cache
+    local cached, staled, flags = require("resty.acme.autossl").get_cert_from_cache(domain, "rsa")
     -- do something to check the domain
     -- return is_domain_included
 end}),

--- a/lib/resty/acme/autossl.lua
+++ b/lib/resty/acme/autossl.lua
@@ -85,6 +85,10 @@ local account_private_key_prefix = "account_key:"
 local certificate_failure_lock_key_prefix = "failure_lock:"
 local certificate_failure_count_prefix = "failed_attempts:"
 
+function AUTOSSL.get_cert_from_cache(domain, typ)
+  return certs_cache[typ]:get(domain)
+end
+
 -- get cert from storage
 local function get_certkey(domain, typ)
   local domain_key = domain_cache_key_prefix .. typ .. ":" .. domain
@@ -106,7 +110,7 @@ end
 
 -- get cert and key cdata with caching
 local function get_certkey_parsed(domain, typ, skip_null_cache)
-  local data, data_staled, _ --[[flags]] = certs_cache[typ]:get(domain)
+  local data, data_staled, _ --[[flags]] = AUTOSSL.get_cert_from_cache(domain, typ)
 
   if data then
     return data, nil


### PR DESCRIPTION
Resolves the need mentioned on https://github.com/fffonion/lua-resty-acme/issues/90.