### PR TITLE
fix(zerossl): concatenate response body as string instead of table

### DIFF
--- a/lib/resty/acme/eab/zerossl-com.lua
+++ b/lib/resty/acme/eab/zerossl-com.lua
@@ -21,11 +21,11 @@ local function handle(account_email)
   local body = json.decode(resp.body)
 
   if not body['success'] then
-    return nil, nil, "zerossl.com API error: " .. body
+    return nil, nil, "zerossl.com API error: " .. resp.body
   end
 
   if not body['eab_kid'] or not body['eab_hmac_key'] then
-    return nil, nil, "zerossl.com API response missing eab_kid or eab_hmac_key: " .. body
+    return nil, nil, "zerossl.com API response missing eab_kid or eab_hmac_key: " .. resp.body
   end
 
   return body['eab_kid'], body['eab_hmac_key']


### PR DESCRIPTION
I noticed some error messages in the Kong logs ```lua entry thread aborted: runtime error: /usr/local/share/lua/5.1/resty/acme/eab/zerossl-com.lua:24: attempt to concatenate local 'body' (a table value)```

`body` is a table which was causing the issue so I updated the error messages to use `resp.body` (string) instead.

@fffonion
