### PR TITLE
feat(autossl): add redis namespace constraint

### DIFF
--- a/lib/resty/acme/autossl.lua
+++ b/lib/resty/acme/autossl.lua
@@ -370,10 +370,14 @@ function AUTOSSL.init(autossl_config, acme_config)
   if acme_config.storage_adapter == "resty.acme.storage.redis" and
     acme_config.storage_config.namespace then
     local namespace = acme_config.storage_config.namespace
-    for _, v in ipairs(reserved_words) do
-      if namespace:find(v, 1, true) == 1 then
-        error("namespace can't be prefixed with reserved word: " .. v)
-      end
+    local re = "^(" .. table.concat(reserved_words, '|') .. ")"
+    local m, err = ngx.re.match(namespace, re, "jo")
+    if err then
+      error("error during ngx.re.match: " .. err)
+    end
+
+    if m then
+      error("namespace can't be prefixed with reserved word: " .. m[0])
     end
   end
 

--- a/lib/resty/acme/autossl.lua
+++ b/lib/resty/acme/autossl.lua
@@ -85,13 +85,14 @@ local account_private_key_prefix = "account_key:"
 local certificate_failure_lock_key_prefix = "failure_lock:"
 local certificate_failure_count_prefix = "failed_attempts:"
 
-local reserved_words = {
+local reserved_words_re = table.concat({
   update_cert_lock_key_prefix,
   domain_cache_key_prefix,
   account_private_key_prefix,
   certificate_failure_lock_key_prefix,
   certificate_failure_count_prefix,
-}
+}, '|')
+reserved_words_re = "^(" .. reserved_words_re .. ")"
 
 function AUTOSSL.get_cert_from_cache(domain, typ)
   return certs_cache[typ]:get(domain)
@@ -370,8 +371,7 @@ function AUTOSSL.init(autossl_config, acme_config)
   if acme_config.storage_adapter == "resty.acme.storage.redis" and
     acme_config.storage_config.namespace then
     local namespace = acme_config.storage_config.namespace
-    local re = "^(" .. table.concat(reserved_words, '|') .. ")"
-    local m, err = ngx.re.match(namespace, re, "jo")
+    local m, err = ngx.re.match(namespace, reserved_words_re, "jo")
     if err then
       error("error during ngx.re.match: " .. err)
     end

--- a/t/autossl.t
+++ b/t/autossl.t
@@ -1,0 +1,89 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua 'no_plan';
+use Cwd qw(cwd);
+
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;$pwd/lib/?/init.lua;$pwd/../lib/?.lua;$pwd/../lib/?/init.lua;;";
+};
+
+run_tests();
+
+__DATA__
+=== TEST 1: should fail if namespace is prefixed with any reserved words
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            require("resty.acme.autossl").init({
+                tos_accepted = true,
+                account_email = "youemail@youdomain.com",
+                domain_whitelist = { "example.com" },
+                storage_adapter = "redis",
+                storage_config = {
+                    namespace = ngx.var.uri:sub(4),
+                }
+            })
+        }
+    }
+--- request
+    GET /t/update_lock%3A
+--- error_code: 500
+--- error_log
+namespace can't be prefixed with reserved word: update_lock:
+--- request
+    GET /t/domain%3Aaaa
+--- error_code: 500
+--- error_log
+namespace can't be prefixed with reserved word: domain:
+--- request
+    GET /t/account_key%3Abbb
+--- error_code: 500
+--- error_log
+namespace can't be prefixed with reserved word: account_key:
+--- request
+    GET /t/failure_lock%3Accc
+--- error_code: 500
+--- error_log
+namespace can't be prefixed with reserved word: failure_lock:
+--- request
+    GET /t/failed_attempts%3Addd
+--- error_code: 500
+--- error_log
+namespace can't be prefixed with reserved word: failed_attempts:
+
+
+=== TEST 2: should success if namespace is not prefixed with any reserved words
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            require("resty.acme.autossl").init({
+                tos_accepted = true,
+                account_email = "youemail@youdomain.com",
+                domain_whitelist = { "example.com" },
+                storage_adapter = "redis",
+                storage_config = {
+                    namespace = ngx.var.uri:sub(4),
+                }
+            })
+        }
+    }
+--- request
+    GET /t/xxxupdate_lock%3A
+--- error_code: 200
+--- no_error_log
+[error]
+--- request
+    GET /t/xxxupdate_lock%3Ayyy
+--- error_code: 200
+--- no_error_log
+[error]
+--- request
+    GET /t/normalname
+--- error_code: 200
+--- no_error_log
+[error]

--- a/t/autossl.t
+++ b/t/autossl.t
@@ -10,12 +10,7 @@ our $HttpConfig = qq{
     lua_package_path "$pwd/lib/?.lua;$pwd/lib/?/init.lua;$pwd/../lib/?.lua;$pwd/../lib/?/init.lua;;";
 };
 
-run_tests();
-
-__DATA__
-=== TEST 1: should fail if namespace is prefixed with any reserved words
---- http_config eval: $::HttpConfig
---- config
+our $TestConfig = q{
     location /t {
         content_by_lua_block {
             require("resty.acme.autossl").init({
@@ -29,59 +24,77 @@ __DATA__
             })
         }
     }
+};
+
+run_tests();
+
+__DATA__
+=== TEST 1: should fail if namespace is prefixed with update_lock:
+--- http_config eval: $::HttpConfig
+--- config eval: $::TestConfig
 --- request
     GET /t/update_lock%3A
 --- error_code: 500
 --- error_log
 namespace can't be prefixed with reserved word: update_lock:
+
+=== TEST 2: should fail if namespace is prefixed with domain:
+--- http_config eval: $::HttpConfig
+--- config eval: $::TestConfig
 --- request
     GET /t/domain%3Aaaa
 --- error_code: 500
 --- error_log
 namespace can't be prefixed with reserved word: domain:
+
+=== TEST 3: should fail if namespace is prefixed with account_key:
+--- http_config eval: $::HttpConfig
+--- config eval: $::TestConfig
 --- request
     GET /t/account_key%3Abbb
 --- error_code: 500
 --- error_log
 namespace can't be prefixed with reserved word: account_key:
+
+=== TEST 4: should fail if namespace is prefixed with failure_lock:
+--- http_config eval: $::HttpConfig
+--- config eval: $::TestConfig
 --- request
     GET /t/failure_lock%3Accc
 --- error_code: 500
 --- error_log
 namespace can't be prefixed with reserved word: failure_lock:
+
+=== TEST 5: should fail if namespace is prefixed with failed_attempts:
+--- http_config eval: $::HttpConfig
+--- config eval: $::TestConfig
 --- request
     GET /t/failed_attempts%3Addd
 --- error_code: 500
 --- error_log
 namespace can't be prefixed with reserved word: failed_attempts:
 
-
-=== TEST 2: should success if namespace is not prefixed with any reserved words
+=== TEST 6: should success if namespace is suffixed with reserved word
 --- http_config eval: $::HttpConfig
---- config
-    location /t {
-        content_by_lua_block {
-            require("resty.acme.autossl").init({
-                tos_accepted = true,
-                account_email = "youemail@youdomain.com",
-                domain_whitelist = { "example.com" },
-                storage_adapter = "redis",
-                storage_config = {
-                    namespace = ngx.var.uri:sub(4),
-                }
-            })
-        }
-    }
+--- config eval: $::TestConfig
 --- request
     GET /t/xxxupdate_lock%3A
 --- error_code: 200
 --- no_error_log
 [error]
+
+=== TEST 7: should success if namespace is infixed with reserved word
+--- http_config eval: $::HttpConfig
+--- config eval: $::TestConfig
 --- request
     GET /t/xxxupdate_lock%3Ayyy
 --- error_code: 200
 --- no_error_log
 [error]
+
+=== TEST 8: should success with other normal namespace
+--- http_config eval: $::HttpConfig
+--- config eval: $::TestConfig
 --- request
     GET /t/normalname
 --- error_code: 200


### PR DESCRIPTION
The namespace can't be prefixed with any of the reserved words.