### PR TITLE
feat: replace redis keys call with scan

### DIFF
--- a/t/storage/redis.t
+++ b/t/storage/redis.t
@@ -431,4 +431,128 @@ nil
 --- no_error_log
 [error]
 
+=== TEST 14: Redis list keys with multiple scan calls
+--- http_config eval: $::HttpConfig
+--- config
+    location =/t {
+        content_by_lua_block {
+            local st = test_lib.new(test_cfg)
+            for i=1,50 do
+                local err = st:set(string.format("test14:%02d", i), string.format("value%02d", i))
+                ngx.say(err)
+            end
+
+            local keys, err = st:list("test14")
+            ngx.say(err)
+            table.sort(keys)
+            for _, p in ipairs(keys) do ngx.say(p) end
+        }
+    }
+--- request
+    GET /t
+--- response_body_like eval
+"nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+nil
+test14:01
+test14:02
+test14:03
+test14:04
+test14:05
+test14:06
+test14:07
+test14:08
+test14:09
+test14:10
+test14:11
+test14:12
+test14:13
+test14:14
+test14:15
+test14:16
+test14:17
+test14:18
+test14:19
+test14:20
+test14:21
+test14:22
+test14:23
+test14:24
+test14:25
+test14:26
+test14:27
+test14:28
+test14:29
+test14:30
+test14:31
+test14:32
+test14:33
+test14:34
+test14:35
+test14:36
+test14:37
+test14:38
+test14:39
+test14:40
+test14:41
+test14:42
+test14:43
+test14:44
+test14:45
+test14:46
+test14:47
+test14:48
+test14:49
+test14:50
+"
+--- no_error_log
+[error]
 


### PR DESCRIPTION
We've started seeing entries in the Redis slowlog related to retrieving keys for `kong_acme:renew_config`. Here is a sample:

```
 1) 1) (integer) 484
    2) (integer) 1693836071
    3) (integer) 14540
    4) 1) "keys"
       2) "kong_acme:renew_config:*"
    5) "<redacted>"
    6) ""
 2) 1) (integer) 483
    2) (integer) 1693833074
    3) (integer) 15386
    4) 1) "keys"
       2) "kong_acme:renew_config:*"
    5) "<redacted>"
    6) ""
 3) 1) (integer) 482
    2) (integer) 1693833067
    3) (integer) 15158
    4) 1) "keys"
       2) "kong_acme:renew_config:*"
    5) "<redacted>"
    6) ""
```

This PR replaces the usage of `keys` with `scan`. Per [Redis documentation](https://redis.io/docs/manual/keyspace/) `scan` is preferred over `keys` in production environments. 

```
Warning: consider [KEYS](https://redis.io/commands/keys) as a command that should only be used in production environments with extreme care.

[KEYS](https://redis.io/commands/keys) may ruin performance when it is executed against large databases. This
command is intended for debugging and special operations, such as changing your keyspace layout. Don't use [KEYS]
https://redis.io/commands/keys) in your regular application code. If you're looking for a way to find keys in a subset of
your keyspace, consider using [SCAN](https://redis.io/commands/scan) or [sets](https://redis.io/topics/data-types#sets).
```

A new config option `scan_count` is introduced to configure how many keys should be returned each call. It defaults to `10` which is the Redis default. Note that Redis does not guarantee that it will obey this value.

An additional test was also added with 50 keys that tests multiple scan calls.