### PR TITLE
Update pebble and challtestsrv images in test docker-compose.yaml; fix t/e2e.t after pebble update

### DIFF
--- a/t/e2e.t
+++ b/t/e2e.t
@@ -169,7 +169,7 @@ __DATA__
 --- request eval
 "GET /t/e2e-test1-$ENV{'tm'}"
 --- response_body_like eval
-"Pebble Intermediate.+CN\\s*=\\s*e2e-test1.+rsaEncryption"
+"Pebble Intermediate.+rsaEncryption.+DNS:e2e-test1"
 --- no_error_log
 [warn]
 [error]
@@ -230,8 +230,7 @@ __DATA__
 --- request eval
 "GET /t/e2e-test2-$ENV{'tm'}"
 --- response_body_like eval
-"Pebble Intermediate.+CN\\s*=\\s*e2e-test2.+rsaEncryption.+Pebble Intermediate.+CN\\s*=\\s*e2e-test2.+id-ecPublicKey
-"
+"Pebble Intermediate.+rsaEncryption.+DNS:e2e-test2.+Pebble Intermediate.+id-ecPublicKey.+DNS:e2e-test2"
 --- no_error_log
 [warn]
 [error]
@@ -278,7 +277,7 @@ set ecc key
 --- request eval
 "GET /t/e2e-test3-$ENV{'tm'}"
 --- response_body_like eval
-"Pebble Intermediate.+CN\\s*=\\s*e2e-test3.+rsaEncryption"
+"Pebble Intermediate.+rsaEncryption.+DNS:e2e-test3"
 --- no_error_log
 [warn]@we allow warn here since we are using plain FFI mode for resty.openssl.ssl
 [error]
@@ -324,7 +323,7 @@ set ecc key
 --- request eval
 "GET /t/e2e-test1-$ENV{'tm'}"
 --- response_body_like eval
-"Pebble Intermediate.+CN\\s*=\\s*e2e-test1.+rsaEncryption"
+"Pebble Intermediate.+rsaEncryption.+DNS:e2e-test1"
 --- no_error_log
 [warn]
 [error]

--- a/t/fixtures/docker-compose.yml
+++ b/t/fixtures/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3'
 services:
   pebble:
-    image: letsencrypt/pebble:latest
-    command: pebble -config /test/config/pebble-config.json -strict -dnsserver 10.30.50.3:8053
+    image: ghcr.io/letsencrypt/pebble:latest
+    command: -config /test/config/pebble-config.json -strict -dnsserver 10.30.50.3:8053
     ports:
       - 14000:14000  # HTTPS ACME API
       - 15000:15000  # HTTPS Management API
@@ -12,8 +12,8 @@ services:
       acmenet:
         ipv4_address: 10.30.50.2
   challtestsrv:
-    image: letsencrypt/pebble-challtestsrv:latest
-    command: pebble-challtestsrv -defaultIPv6 "" -defaultIPv4 10.30.50.1
+    image: ghcr.io/letsencrypt/pebble-challtestsrv:latest
+    command: -defaultIPv6 "" -defaultIPv4 10.30.50.1
     ports:
       - 8055:8055  # HTTP Management API
     networks:


### PR DESCRIPTION
These images have [moved to ghcr.io](https://github.com/letsencrypt/pebble/pull/450), and are no longer available in Docker Hub. Also, the command syntax has changed (program name is no longed accepted as first argument to the container).

I have tested the docker compose setup locally, but I can't confirm whether this breaks tests or not - they keep failing in my environment for possibly unrelated reason.